### PR TITLE
> nextn@0.1.0 dev

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "IDX.aI.enableInlineCompletion": true,
+    "IDX.aI.enableCodebaseIndexing": true
+}

--- a/src/app/api/tunnels/route.ts
+++ b/src/app/api/tunnels/route.ts
@@ -1,0 +1,15 @@
+
+import { NextResponse } from 'next/server';
+import { getTunnels } from '@/lib/configServer';
+
+export const dynamic = 'force-dynamic'; // Ensures the route is re-evaluated on each request
+
+export async function GET() {
+  try {
+    const tunnels = await getTunnels();
+    return NextResponse.json(tunnels);
+  } catch (error) {
+    console.error('Error fetching tunnels for API:', error);
+    return NextResponse.json({ message: 'Failed to fetch tunnels configuration.' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
> next dev --turbopack -p 3000

   ▲ Next.js 15.2.3 (Turbopack)
   - Local:        http://localhost:3000
   - Network:      http://192.168.3.4:3000

 ✓ Starting...
 ✓ Compiled in 408ms
 ✓ Ready in 2.9s
 ⨯ Error: The edge runtime does not support Node.js 'path' module.
Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime
    at Object.get (.next\server\edge\chunks\_94a4b977._.js:62:41)
    at [project]/src/lib/configServer.ts [middleware-edge] (ecmascript) (.next\server\edge\chunks\[root of the server]__051af1f9._.js:43:137)
    at <unknown> (.next\server\edge\chunks\edge-wrapper_1fade9cf.js:709:27)
    at runModuleExecutionHooks (.next\server\edge\chunks\edge-wrapper_1fade9cf.js:755:9)
    at instantiateModule (.next\server\edge\chunks\edge-wrapper_1fade9cf.js:707:9)
    at getOrInstantiateModuleFromParent (.next\server\edge\chunks\edge-wrapper_1fade9cf.js:640:12)
    at esmImport (.next\server\edge\chunks\edge-wrapper_1fade9cf.js:143:20)
    at [project]/src/middleware.ts [middleware-edge] (ecmascript) (.next\server\edge\chunks\[root of the server]__051af1f9._.js:105:160)
    at <unknown> (.next\server\edge\chunks\edge-wrapper_1fade9cf.js:709:27)
    at runModuleExecutionHooks (.next\server\edge\chunks\edge-wrapper_1fade9cf.js:755:9)
 ⚠ ./src/lib/configServer.ts:5:27
Ecmascript file had an error
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |
> 5 | const dataDir = path.join(process.cwd(), 'src', 'data');
    |                           ^^^^^^^^^^^
  6 | const tunnelsFilePath = path.join(dataDir, 'tunnels.json');
  7 |
  8 | async function ensureDataFileExists(): Promise<void> {

A Node.js API is used (process.cwd at line: 5) which is not supported in the Edge Runtime.
Learn more: https://nextjs.org/docs/api-reference/edge-runtime

 ⚠ ./src/lib/configServer.ts:1:1
Ecmascript file had an error
> 1 | import fs from 'fs/promises';
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  2 | import path from 'path';
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |

A Node.js module is loaded ('fs/promises' at line 1) which is not supported in the Edge Runtime. Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime

 ⚠ ./src/lib/configServer.ts:2:1
Ecmascript file had an error
  1 | import fs from 'fs/promises';
> 2 | import path from 'path';
    | ^^^^^^^^^^^^^^^^^^^^^^^^
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |
  5 | const dataDir = path.join(process.cwd(), 'src', 'data');

A Node.js module is loaded ('path' at line 2) which is not supported in the Edge Runtime. Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime

 ○ Compiling /_error ...
 ✓ Compiled /_error in 1904ms
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
    at ShadowPortal (C:\Users\Rectorat06\Documents\GitHub\Panda-reverse-proxy\node_modules\next\src\client\components\react-dev-overlay\ui\components\shadow-portal.tsx:5:32)
    at DevOverlay (C:\Users\Rectorat06\Documents\GitHub\Panda-reverse-proxy\node_modules\next\src\client\components\react-dev-overlay\ui\dev-overlay.tsx:14:3)
    at ReactDevOverlay (C:\Users\Rectorat06\Documents\GitHub\Panda-reverse-proxy\node_modules\next\src\server\dev\next-dev-server.ts:82:10)
    at div
    at Body (webpack://next/dist/src/server/render.tsx:1263:19)
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
    at ShadowPortal (C:\Users\Rectorat06\Documents\GitHub\Panda-reverse-proxy\node_modules\next\src\client\components\react-dev-overlay\ui\components\shadow-portal.tsx:5:32)
    at DevOverlay (C:\Users\Rectorat06\Documents\GitHub\Panda-reverse-proxy\node_modules\next\src\client\components\react-dev-overlay\ui\dev-overlay.tsx:14:3)
    at ReactDevOverlay (C:\Users\Rectorat06\Documents\GitHub\Panda-reverse-proxy\node_modules\next\src\server\dev\next-dev-server.ts:82:10)
    at div
    at Body (webpack://next/dist/src/server/render.tsx:1263:19)
 GET / 404 in 14ms
 ⚠ ./src/lib/configServer.ts:5:27
Ecmascript file had an error
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |
> 5 | const dataDir = path.join(process.cwd(), 'src', 'data');
    |                           ^^^^^^^^^^^
  6 | const tunnelsFilePath = path.join(dataDir, 'tunnels.json');
  7 |
  8 | async function ensureDataFileExists(): Promise<void> {

A Node.js API is used (process.cwd at line: 5) which is not supported in the Edge Runtime.
Learn more: https://nextjs.org/docs/api-reference/edge-runtime

 ⚠ ./src/lib/configServer.ts:1:1
Ecmascript file had an error
> 1 | import fs from 'fs/promises';
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  2 | import path from 'path';
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |

A Node.js module is loaded ('fs/promises' at line 1) which is not supported in the Edge Runtime. Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime

 ⚠ ./src/lib/configServer.ts:2:1
Ecmascript file had an error
  1 | import fs from 'fs/promises';
> 2 | import path from 'path';
    | ^^^^^^^^^^^^^^^^^^^^^^^^
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |
  5 | const dataDir = path.join(process.cwd(), 'src', 'data');

A Node.js module is loaded ('path' at line 2) which is not supported in the Edge Runtime. Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime

 ○ Compiling /_not-found/page ...
 ⚠ ./src/lib/configServer.ts:5:27
Ecmascript file had an error
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |
> 5 | const dataDir = path.join(process.cwd(), 'src', 'data');
    |                           ^^^^^^^^^^^
  6 | const tunnelsFilePath = path.join(dataDir, 'tunnels.json');
  7 |
  8 | async function ensureDataFileExists(): Promise<void> {

A Node.js API is used (process.cwd at line: 5) which is not supported in the Edge Runtime.
Learn more: https://nextjs.org/docs/api-reference/edge-runtime

 ⚠ ./src/lib/configServer.ts:1:1
Ecmascript file had an error
> 1 | import fs from 'fs/promises';
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  2 | import path from 'path';
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |

A Node.js module is loaded ('fs/promises' at line 1) which is not supported in the Edge Runtime. Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime

 ⚠ ./src/lib/configServer.ts:2:1
Ecmascript file had an error
  1 | import fs from 'fs/promises';
> 2 | import path from 'path';
    | ^^^^^^^^^^^^^^^^^^^^^^^^
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |
  5 | const dataDir = path.join(process.cwd(), 'src', 'data');

A Node.js module is loaded ('path' at line 2) which is not supported in the Edge Runtime. Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime

 GET /favicon.ico 200 in 3057ms
 ✓ Compiled /_not-found/page in 6.6s
 ⚠ ./src/lib/configServer.ts:5:27
Ecmascript file had an error
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |
> 5 | const dataDir = path.join(process.cwd(), 'src', 'data');
    |                           ^^^^^^^^^^^
  6 | const tunnelsFilePath = path.join(dataDir, 'tunnels.json');
  7 |
  8 | async function ensureDataFileExists(): Promise<void> {

A Node.js API is used (process.cwd at line: 5) which is not supported in the Edge Runtime.
Learn more: https://nextjs.org/docs/api-reference/edge-runtime

 ⚠ ./src/lib/configServer.ts:1:1
Ecmascript file had an error
> 1 | import fs from 'fs/promises';
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  2 | import path from 'path';
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |

A Node.js module is loaded ('fs/promises' at line 1) which is not supported in the Edge Runtime. Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime

 ⚠ ./src/lib/configServer.ts:2:1
Ecmascript file had an error
  1 | import fs from 'fs/promises';
> 2 | import path from 'path';
    | ^^^^^^^^^^^^^^^^^^^^^^^^
  3 | import type { Tunnel } from '@/types/tunnel';
  4 |
  5 | const dataDir = path.join(process.cwd(), 'src', 'data');

A Node.js module is loaded ('path' at line 2) which is not supported in the Edge Runtime. Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime